### PR TITLE
fix: modified to use the latest terraform version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ Create a custom DNS service, zones, records. Users can also optionally create a 
 
 ## Table of Contents
 
-1. [DNS Service](#dns-service)
-2. [DNS Zones](#dns-zones)
-3. [DNS Records](#dns-records)
-4. [Custom Resolvers](#custom-resolvers)
-5. [Module Variables](#module-variables)
-6. [Module Outputs](#module-outputs)
+- [IBM Cloud Solution Engineering VPC Custom DNS Module](#ibm-cloud-solution-engineering-vpc-custom-dns-module)
+  - [Table of Contents](#table-of-contents)
+  - [DNS Service](#dns-service)
+  - [DNS Zones](#dns-zones)
+  - [DNS Records](#dns-records)
+  - [Custom Resolvers](#custom-resolvers)
+    - [Custom Resolver Variable](#custom-resolver-variable)
+  - [Module Variables](#module-variables)
+  - [Module Outputs](#module-outputs)
 
 ---
 
@@ -121,7 +124,7 @@ variable "custom_resolvers" {
 
 Name                   | Type                                                                                                                                                                                                                                                                                                                                                                             | Description                                                                                                                                                                                                                             | Sensitive | Default
 ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | -------
-TF_VERSION             | string                                                                                                                                                                                                                                                                                                                                                                           | The version of the Terraform engine that's used in the Schematics workspace.                                                                                                                                                            |           | 1.0
+TF_VERSION             | string                                                                                                                                                                                                                                                                                                                                                                           | The version of the Terraform engine that's used in the Schematics workspace.                                                                                                                                                            |           | 1.3.0
 prefix                 | string                                                                                                                                                                                                                                                                                                                                                                           | A unique identifier for resources. Must begin with a lowercase letter and end with a lowerccase letter or number. This prefix will be prepended to any resources provisioned by this template. Prefixes must be 16 or fewer characters. |           | 
 region                 | string                                                                                                                                                                                                                                                                                                                                                                           | Region where DNS components will be provisioned To find your VPC region, use `ibmcloud is regions` command to find available regions.                                                                                                   |           | 
 resource_group_id      | string                                                                                                                                                                                                                                                                                                                                                                           | ID of the resource group where DNS components will be provisioned                                                                                                                                                                       |           | null

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@
 ##############################################################################
 
 variable "TF_VERSION" {
-  default     = "1.0"
+  default     = "1.3.0"
   type        = string
   description = "The version of the Terraform engine that's used in the Schematics workspace."
 }

--- a/versions.tf
+++ b/versions.tf
@@ -9,8 +9,7 @@ terraform {
       version = "~>1.43.0"
     }
   }
-  required_version = ">=1.0"
-  experiments      = [module_variable_optional_attrs]
+  required_version = ">=1.3.0"
 }
 
 ##############################################################################


### PR DESCRIPTION
### Description

- Optional attributes are removed in order to support latest Terraform version i.e.
   `experiments = [module_variable_optional_attrs]`
- Terraform version is updated i.e.`required_version = ">= 1.3.0"`

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [x] New feature (nonbreaking change that adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [x] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
